### PR TITLE
SNO2-34-pull-item-columns-from-search-config-instead-of-schema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest==6.2.5
+    pytest==5.3.2
     pytest-mock==2.0.0
     pytest-cov==2.8.1
     pyramid==1.10.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 
 [options.extras_require]
 test =
-    pytest==5.3.2
+    pytest==6.2.5
     pytest-mock==2.0.0
     pytest-cov==2.8.1
     pyramid==1.10.4

--- a/src/snosearch/queries.py
+++ b/src/snosearch/queries.py
@@ -251,7 +251,7 @@ class AbstractQueryFactory:
 
     def _get_columns_for_item_type(self, item_type):
         return self._get_search_config_for_item_type(item_type).get(COLUMNS, {})
-    
+
     def _get_columns_for_item_types(self, item_types=None):
         columns = self._get_base_columns()
         item_type_values = item_types or self.params_parser.param_values_to_list(

--- a/src/snosearch/queries.py
+++ b/src/snosearch/queries.py
@@ -250,8 +250,8 @@ class AbstractQueryFactory:
         }
 
     def _get_columns_for_item_type(self, item_type):
-        return self._get_schema_for_item_type(item_type).get(COLUMNS, {})
-
+        return self._get_search_config_for_item_type(item_type).get(COLUMNS, {})
+    
     def _get_columns_for_item_types(self, item_types=None):
         columns = self._get_base_columns()
         item_type_values = item_types or self.params_parser.param_values_to_list(

--- a/src/snosearch/tests/test_searches_queries.py
+++ b/src/snosearch/tests/test_searches_queries.py
@@ -504,7 +504,6 @@ def test_searches_queries_abstract_query_factory_get_columns_from_configs_or_ite
     from snosearch.queries import AbstractQueryFactory
     from snosearch.interfaces import SEARCH_CONFIG
     search_registry = dummy_request.registry[SEARCH_CONFIG]
-    print("search_registry:", search_registry.as_dict())
     dummy_request.environ['QUERY_STRING'] = (
         'status=released&type=TestingSearchSchema'
     )

--- a/src/snosearch/tests/test_searches_queries.py
+++ b/src/snosearch/tests/test_searches_queries.py
@@ -504,6 +504,7 @@ def test_searches_queries_abstract_query_factory_get_columns_from_configs_or_ite
     from snosearch.queries import AbstractQueryFactory
     from snosearch.interfaces import SEARCH_CONFIG
     search_registry = dummy_request.registry[SEARCH_CONFIG]
+    print("search_registry:", search_registry.as_dict())
     dummy_request.environ['QUERY_STRING'] = (
         'status=released&type=TestingSearchSchema'
     )
@@ -548,6 +549,19 @@ def test_searches_queries_abstract_query_factory_get_columns_from_configs_or_ite
         '@id': {'title': 'ID'},
         'accession': {'title': 'Accession'},
         'status': {'title': 'Status'}
+    }
+    dummy_request.environ['QUERY_STRING'] = (
+        'status=released&type=TestingDownload'
+        '&type=TestingSearchSchema'
+    )
+    params_parser = ParamsParser(dummy_request)
+    aq = AbstractQueryFactory(params_parser)
+    columns = aq._get_columns_from_configs_or_item_types()
+    assert dict(columns) == {
+        '@id': {'title': 'ID'},
+        'accession': {'title': 'Accession'},
+        'status': {'title': 'Status'},
+        'attachment': {'title': 'Attachment'}
     }
     defaults = {
         ('TestingPostPutPatch', 'TestingSearchSchema'): ['TestingDownload']


### PR DESCRIPTION
Also bumped pytest version to make tests work.